### PR TITLE
Fix CSS loading path

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,8 +1,10 @@
 import streamlit as st
+import os
 
 st.set_page_config(page_title="Parcel Viewer", layout="wide")
 
-with open("style.css") as f:
+css_path = os.path.join(os.path.dirname(__file__), "style.css")
+with open(css_path) as f:
     st.markdown(f"<style>{f.read()}</style>", unsafe_allow_html=True)
 
 import requests, folium, pandas as pd, re


### PR DESCRIPTION
### **User description**
## Summary
- ensure style.css loads properly regardless of working directory

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6878e0bf35a08327bfe606ef520d56f2


___

### **PR Type**
Bug fix


___

### **Description**
- Fix CSS loading path to work from any directory

- Use `os.path.join` with `__file__` for absolute path resolution


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hard-coded CSS path"] --> B["Absolute path resolution"]
  B --> C["CSS loads from any directory"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>app.py</strong><dd><code>Fix CSS path resolution using absolute paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app.py

<li>Import <code>os</code> module for path operations<br> <li> Replace hard-coded <code>"style.css"</code> with absolute path using <code>os.path.join</code><br> <li> Use <code>os.path.dirname(__file__)</code> to get script directory


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/MappingKML/pull/6/files#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

