### PR TITLE
Fix CSS path

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,9 +1,17 @@
 import streamlit as st
+from pathlib import Path
 
 st.set_page_config(page_title="Parcel Viewer", layout="wide")
 
-with open("style.css") as f:
-    st.markdown(f"<style>{f.read()}</style>", unsafe_allow_html=True)
+css_path = Path(__file__).resolve().parent / "style.css"
+if css_path.exists():
+    try:
+        css = css_path.read_text()
+        st.markdown(f"<style>{css}</style>", unsafe_allow_html=True)
+    except Exception as e:  # pragma: no cover - debug helper
+        st.error(f"Failed to load CSS: {e}")
+else:
+    st.warning(f"CSS file not found: {css_path}")
 
 import requests, folium, pandas as pd, re
 from st_aggrid import AgGrid, GridOptionsBuilder, GridUpdateMode


### PR DESCRIPTION
## Summary
- load `style.css` using an absolute path
- warn if the stylesheet is missing and show an error if loading fails

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6878e0bf35a08327bfe606ef520d56f2