### PR TITLE
Add shapefile and bounds tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,43 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+@pytest.fixture
+def qld_feature():
+    return {
+        "type": "Feature",
+        "properties": {"lot": "1", "plan": "RP12345"},
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [[[150.0, -28.0], [150.1, -28.0], [150.1, -28.1], [150.0, -28.1], [150.0, -28.0]]],
+        },
+    }
+
+
+@pytest.fixture
+def nsw_feature():
+    return {
+        "type": "Feature",
+        "properties": {"lotnumber": "2", "sectionnumber": "1", "planlabel": "DP67890"},
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [[[150.2, -33.8], [150.3, -33.8], [150.3, -33.9], [150.2, -33.9], [150.2, -33.8]]],
+        },
+    }
+
+
+@pytest.fixture
+def multipolygon_feature():
+    return {
+        "type": "Feature",
+        "properties": {},
+        "geometry": {
+            "type": "MultiPolygon",
+            "coordinates": [
+                [[[150.2, -33.8], [150.3, -33.8], [150.3, -33.9], [150.2, -33.9], [150.2, -33.8]]],
+                [[[150.4, -33.7], [150.5, -33.7], [150.5, -33.8], [150.4, -33.8], [150.4, -33.7]]],
+            ],
+        },
+    }

--- a/tests/test_generate_shapefile.py
+++ b/tests/test_generate_shapefile.py
@@ -1,0 +1,12 @@
+import io
+import zipfile
+
+import kml_utils as kml
+
+
+def test_generate_shapefile_zip_contents(qld_feature):
+    shp_bytes = kml.generate_shapefile([qld_feature], "QLD")
+    with zipfile.ZipFile(io.BytesIO(shp_bytes)) as z:
+        names = set(z.namelist())
+    expected = {"parcels.shp", "parcels.shx", "parcels.dbf", "parcels.prj"}
+    assert expected.issubset(names)

--- a/tests/test_get_bounds.py
+++ b/tests/test_get_bounds.py
@@ -1,0 +1,13 @@
+import kml_utils as kml
+
+
+def test_get_bounds_polygon(qld_feature):
+    expected = [[-28.1, 150.0], [-28.0, 150.1]]
+    bounds = kml.get_bounds([qld_feature])
+    assert bounds == expected
+
+
+def test_get_bounds_multipolygon(multipolygon_feature):
+    expected = [[-33.9, 150.2], [-33.7, 150.5]]
+    bounds = kml.get_bounds([multipolygon_feature])
+    assert bounds == expected


### PR DESCRIPTION
### **User description**
## Summary
- add fixtures for reusable sample features
- add unit test for `generate_shapefile`
- add unit tests for `get_bounds`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878ec9c20f48327bf6f75f18c343e85


___

### **PR Type**
Tests


___

### **Description**
- Add reusable GeoJSON feature fixtures for testing

- Add unit test for `generate_shapefile` function

- Add unit tests for `get_bounds` function


___

### Diagram Walkthrough


```mermaid
flowchart LR
  fixtures["Test Fixtures"] --> shapefile_test["Shapefile Tests"]
  fixtures --> bounds_test["Bounds Tests"]
  shapefile_test --> validation["ZIP Content Validation"]
  bounds_test --> polygon["Polygon Bounds"]
  bounds_test --> multipolygon["MultiPolygon Bounds"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>conftest.py</strong><dd><code>Add GeoJSON feature fixtures for testing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/conftest.py

<li>Add three pytest fixtures for GeoJSON features<br> <li> Include QLD and NSW polygon features with properties<br> <li> Add multipolygon feature for complex geometry testing


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/MappingKML/pull/8/files#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_generate_shapefile.py</strong><dd><code>Add shapefile generation unit test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_generate_shapefile.py

<li>Test <code>generate_shapefile</code> function with QLD feature<br> <li> Verify ZIP file contains required shapefile components<br> <li> Check for .shp, .shx, .dbf, and .prj files


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/MappingKML/pull/8/files#diff-5c144e1714dbeaf9615823adb92dc2f4e68f41a2dae2c79a869af0c53ccd93ac">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_get_bounds.py</strong><dd><code>Add bounds calculation unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_get_bounds.py

<li>Test <code>get_bounds</code> function with polygon geometry<br> <li> Test <code>get_bounds</code> function with multipolygon geometry<br> <li> Verify correct bounding box calculations


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/MappingKML/pull/8/files#diff-d3739925a15aca2def127876ac17f72973d28401b01b9bf1f59ffb7c503f7408">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

