### PR TITLE
Embed CSS fallback in app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,89 @@
 import streamlit as st
 from pathlib import Path
 
+EMBEDDED_CSS = """
+/* Hide Streamlit header/footer for a clean UI */
+#MainMenu, footer, header {
+  visibility: hidden !important;
+}
+
+/* Sidebar styling */
+[data-testid="stSidebar"] {
+  background-color: #2b3035 !important;
+}
+[data-testid="stSidebar"] * {
+  color: #fafafa !important;
+}
+[data-testid="stSidebar"] .stTextInput input,
+[data-testid="stSidebar"] .stTextArea textarea {
+  background-color: #3e444a !important;
+  color: #fafafa !important;
+}
+
+/* Main content background */
+[data-testid="stAppViewContainer"] {
+  background-color: #0e1117 !important;
+  color: #fafafa;
+}
+
+/* Folium basemap controls */
+.leaflet-control-layers-list {
+  background: rgba(40, 40, 40, 0.8) !important;
+  color: #fafafa !important;
+}
+
+/* Results table hide index column */
+.kvDataTable table {
+  font-size: 0.9em;
+}
+
+/* Loading spinner */
+.loading-icon {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 40px;
+  height: 40px;
+  border: 4px solid #f3f3f3;
+  border-top: 4px solid #00ff00;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  z-index: 1000;
+  display: none;
+}
+
+@keyframes spin {
+  0% {
+    transform: translate(-50%, -50%) rotate(0deg);
+  }
+  100% {
+    transform: translate(-50%, -50%) rotate(360deg);
+  }
+}
+
+.loading-active .loading-icon {
+  display: block;
+}
+
+/* Map sizing */
+[data-testid="stAppViewContainer"] .main .block-container {
+  padding: 0;
+}
+
+.map-container {
+  height: 100vh;
+  width: 100%;
+  overflow: auto;
+}
+
+.map-container iframe {
+  height: 100%;
+  width: 100%;
+  border: none;
+}
+"""
+
 st.set_page_config(page_title="Parcel Viewer", layout="wide")
 
 css_path = Path(__file__).resolve().parent / "style.css"
@@ -12,6 +95,7 @@ if css_path.exists():
         st.error(f"Failed to load CSS: {e}")
 else:
     st.warning(f"CSS file not found: {css_path}")
+    st.markdown(f"<style>{EMBEDDED_CSS}</style>", unsafe_allow_html=True)
 
 import requests, folium, pandas as pd, re
 from st_aggrid import AgGrid, GridOptionsBuilder, GridUpdateMode


### PR DESCRIPTION
## Summary
- embed style.css in `app.py` as `EMBEDDED_CSS`
- use embedded CSS when `style.css` isn't found

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878ec9158f083278959057fb1798b54