### PR TITLE
Adjust styling inputs for fill opacity and outline weight

### DIFF
--- a/app.py
+++ b/app.py
@@ -112,14 +112,31 @@ with st.sidebar:
 
     if st.session_state.get("features"):
         with st.expander("Styling Options", expanded=True):
-            fill_color = st.color_picker("Fill color", "#FF0000", key="fill_color")
-            outline_color = st.color_picker(
-                "Outline color", "#000000", key="outline_color"
-            )
-            fill_opacity = st.slider(
-                "Fill opacity", 0.0, 1.0, 0.5, step=0.01, key="fill_opacity"
-            )
-            outline_weight = st.slider("Outline weight", 1, 10, 2, key="outline_weight")
+            fc_col, fo_col = st.columns([2, 1])
+            with fc_col:
+                fill_color = st.color_picker("Fill color", "#FF0000", key="fill_color")
+            with fo_col:
+                fill_opacity = st.number_input(
+                    "Opacity",
+                    min_value=0.0,
+                    max_value=1.0,
+                    value=0.5,
+                    step=0.01,
+                    key="fill_opacity",
+                )
+
+            oc_col, ow_col = st.columns([2, 1])
+            with oc_col:
+                outline_color = st.color_picker("Outline color", "#000000", key="outline_color")
+            with ow_col:
+                outline_weight = st.number_input(
+                    "Weight",
+                    min_value=1,
+                    max_value=10,
+                    value=2,
+                    step=1,
+                    key="outline_weight",
+                )
         with st.expander("Export Options", expanded=True):
             folder_name = st.text_input(
                 "KML Folder Name", value="Parcels", key="folder_name"


### PR DESCRIPTION
### **User description**
## Summary
- replace sliders with number inputs for fill opacity and outline weight
- align opacity and weight fields beside their color pickers
- add missing dependency to run tests

## Testing
- `pip install -q pyshp==2.3.1`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878f9ccc08883279df259b57a3a9738


___

### **PR Type**
Enhancement


___

### **Description**
- Replace sliders with number inputs for fill opacity and outline weight

- Reorganize styling controls into column layout for better alignment

- Position opacity and weight fields beside their color pickers


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Color Picker"] -- "aligned with" --> B["Number Input"]
  C["Fill Color"] -- "paired with" --> D["Fill Opacity"]
  E["Outline Color"] -- "paired with" --> F["Outline Weight"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>app.py</strong><dd><code>Update styling controls to use number inputs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app.py

<li>Replace <code>st.slider</code> with <code>st.number_input</code> for fill opacity and outline <br>weight<br> <li> Add column layout using <code>st.columns([2, 1])</code> for better alignment<br> <li> Position opacity and weight inputs beside their respective color <br>pickers<br> <li> Maintain same value ranges and defaults for all controls


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/MappingKML/pull/15/files#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959">+25/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

