### PR TITLE
Add Kepler.gl React plugin example

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import KeplerGl from 'kepler.gl';
+import keplerPlugin from './keplerPlugin';
+
+function App() {
+  return (
+    <div style={{position: 'absolute', width: '100%', height: '100%'}}>
+      <KeplerGl
+        id="map"
+        mapboxApiAccessToken={process.env.REACT_APP_MAPBOX_TOKEN}
+        plugins={[keplerPlugin]}
+      />
+    </div>
+  );
+}
+
+export default App;

--- a/src/QuerySearchPanel.jsx
+++ b/src/QuerySearchPanel.jsx
@@ -1,0 +1,46 @@
+import React, {useState} from 'react';
+
+const mockData = [
+  { id: 1, lot: 'LotA', plan: 'PlanX' },
+  { id: 2, lot: 'LotB', plan: 'PlanY' }
+];
+
+export default function QuerySearchPanel() {
+  const [input, setInput] = useState('');
+  const [results, setResults] = useState([]);
+
+  const onSearch = async () => {
+    await new Promise(r => setTimeout(r, 500));
+    setResults(mockData);
+  };
+
+  return (
+    <div style={{padding: '1rem'}}>
+      <h3>Lot / Plan Search</h3>
+      <textarea
+        rows={4}
+        style={{width: '100%'}}
+        placeholder="One lot/plan per line"
+        value={input}
+        onChange={e => setInput(e.target.value)}
+      />
+      <button onClick={onSearch} style={{marginTop: '0.5rem'}}>Search</button>
+      <div style={{marginTop: '1rem', maxHeight: '200px', overflowY: 'auto'}}>
+        {results.length > 0 ? (
+          <table>
+            <thead>
+              <tr><th>ID</th><th>Lot</th><th>Plan</th></tr>
+            </thead>
+            <tbody>
+              {results.map(r =>
+                <tr key={r.id}>
+                  <td>{r.id}</td><td>{r.lot}</td><td>{r.plan}</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        ) : <div>No results yet.</div>}
+      </div>
+    </div>
+  );
+}

--- a/src/keplerPlugin.js
+++ b/src/keplerPlugin.js
@@ -1,0 +1,16 @@
+import {injectComponents} from 'kepler.gl';
+import QuerySearchPanel from './QuerySearchPanel';
+
+const plugin = {
+  SidePanelFactory: {
+    components: {
+      querySearch: {
+        id: 'querySearch',
+        label: 'Query Search',
+        component: QuerySearchPanel
+      }
+    }
+  }
+};
+
+export default plugin;


### PR DESCRIPTION
## Summary
- add React sample using Kepler.gl plugin system
- provide custom `QuerySearchPanel` component and plugin
- example `App.jsx` integrates the plugin

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886203d9ffc83278a22876ddc4995b7