### PR TITLE
Fix dependency version for streamlit-keplergl

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 streamlit==1.36.0
-streamlit-keplergl==0.3.1
+streamlit-keplergl==0.3.0
 keplergl==0.3.2
 pandas==2.2.2
 shapely==2.0.6


### PR DESCRIPTION
## Summary
- pin `streamlit-keplergl` to version 0.3.0 because 0.3.1 does not exist on PyPI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68862b2c25d08327978aa03a8a78f4b6