### PR TITLE
Fix KeplerGl instantiation with empty dataset

### DIFF
--- a/app.py
+++ b/app.py
@@ -424,5 +424,9 @@ if bbox and "config" in cfg and "mapState" in cfg["config"]:
     cfg["config"]["mapState"]["latitude"] = center_lat
     cfg["config"]["mapState"]["zoom"] = cfg["config"]["mapState"].get("zoom", 9)
 # Pass datasets via data= so Kepler auto-adds layers
-m = KeplerGl(height=800, data=data_bundle if data_bundle else None, config=cfg if cfg else None)
+# KeplerGl expects a dictionary for the `data` trait. When no datasets are
+# loaded `data_bundle` will be an empty dict which evaluates to ``False`` in
+# a boolean context. Passing ``None`` results in a TraitError, so always pass
+# a dictionary.
+m = KeplerGl(height=800, data=data_bundle or {}, config=cfg or {})
 keplergl_static(m)


### PR DESCRIPTION
## Summary
- ensure KeplerGl always receives a dictionary for data/config

## Testing
- `pytest -q`
- `python app.py`

------
https://chatgpt.com/codex/tasks/task_e_6886f3774e2083279b57c2d13b3aa039