### PR TITLE
Add lot/plan popups

### DIFF
--- a/kml_utils.py
+++ b/kml_utils.py
@@ -83,12 +83,12 @@ def generate_kml(
         if region == "QLD":
             lot = props.get("lot", "")
             plan = props.get("plan", "")
-            placename = f"Lot {lot} Plan {plan}"
+            lotplan = props.get("lotplan") or f"{lot}{plan}"
         else:
             lot = props.get("lotnumber", "")
-            sec = props.get("sectionnumber", "") or ""
             planlabel = props.get("planlabel", "")
-            placename = f"Lot {lot} {('Section ' + sec + ' ') if sec else ''}{planlabel}"
+            lotplan = f"{lot}{planlabel}"
+        placename = lotplan
 
         # Build up ExtendedData elements.  These fields mirror those used in
         # Queensland Globe exports.  Additional metadata could be added here

--- a/tests/test_generate_kml.py
+++ b/tests/test_generate_kml.py
@@ -46,7 +46,7 @@ def test_generate_kml_qld():
     root = parse_kml(result)
     ns = {"k": "http://www.opengis.net/kml/2.2"}
     name = root.find(".//k:Placemark/k:name", ns)
-    assert name is not None and name.text == "Lot 1 Plan RP12345"
+    assert name is not None and name.text == "1RP12345"
     fill = root.find(".//k:PolyStyle/k:color", ns)
     assert fill.text == kml._hex_to_kml_color("#123456", 0.3)
 
@@ -57,6 +57,6 @@ def test_generate_kml_nsw():
     root = parse_kml(result)
     ns = {"k": "http://www.opengis.net/kml/2.2"}
     name = root.find(".//k:Placemark/k:name", ns)
-    assert name is not None and name.text == "Lot 2 Section 1 DP67890"
+    assert name is not None and name.text == "2DP67890"
     fill = root.find(".//k:PolyStyle/k:color", ns)
     assert fill.text == kml._hex_to_kml_color("#abcdef", 0.8)


### PR DESCRIPTION
## Summary
- compute canonical lot/plan properties for query results
- show those properties in a pydeck tooltip popup
- name KML placemarks with the lot/plan string
- update tests for new KML name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889f5435a0c8327890884017eab0cb9