### PR TITLE
Add shapefile download option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MappingKML — Streamlit Mapbox Viewer
 
-This version displays query results on a **Mapbox** map using `pydeck`.  The sidebar lets you search for Lot/Plan polygons and export the results as KML.
+This version displays query results on a **Mapbox** map using `pydeck`.  The sidebar lets you search for Lot/Plan polygons and export the results as either KML or a zipped shapefile.
 
 ## Install & Run
 ```bash
@@ -12,7 +12,7 @@ streamlit run app.py
 
 * Enter a Lot/Plan pattern (e.g. `169-173, 203 // DP753311` or `1RP912949`).
 * Implement `run_lotplan_query()` in `app.py` to call your cadastral service and return a GeoJSON `FeatureCollection`.
-* Query results are rendered on the map and can be downloaded as KML.
+* Query results are rendered on the map and can be downloaded as KML or as a zipped shapefile archive.
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -322,7 +322,15 @@ with st.sidebar.expander("Export / Download", expanded=False):
         _canonicalize_feature_props(f)
     if features:
         region = "NSW" if any("planlabel" in (f.get("properties") or {}) for f in features) else "QLD"
-        kml_str = kml_utils.generate_kml(features, region, fill_hex, fill_opacity, outline_hex, outline_weight, folder_name)
+        kml_str = kml_utils.generate_kml(
+            features,
+            region,
+            fill_hex,
+            fill_opacity,
+            outline_hex,
+            outline_weight,
+            folder_name,
+        )
         st.download_button(
             "Download KML",
             data=kml_str.encode("utf-8"),
@@ -330,6 +338,17 @@ with st.sidebar.expander("Export / Download", expanded=False):
             mime="application/vnd.google-earth.kml+xml",
             use_container_width=True,
         )
+        try:
+            shp_bytes = kml_utils.generate_shapefile(features, region)
+            st.download_button(
+                "Download Shapefile",
+                data=shp_bytes,
+                file_name=f"{folder_name}.zip",
+                mime="application/zip",
+                use_container_width=True,
+            )
+        except RuntimeError as e:
+            st.warning(str(e))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add shapefile export button to sidebar export section
- update README to mention shapefile downloads

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889f92c7b308327a835127d7d871705