### PR TITLE
refactor: centralize byte conversion

### DIFF
--- a/app.py
+++ b/app.py
@@ -651,6 +651,23 @@ view_state=_fit_view(fc_all if accum_features else None)
 deck=pdk.Deck(layers=layers, initial_view_state=view_state, map_style=None, tooltip={"html":tooltip_html})
 st.pydeck_chart(deck, use_container_width=True)
 
+# --- minimal helper to ensure Streamlit always gets raw bytes ---
+def _as_bytes(x):
+    try:
+        if x is None:
+            return b""
+        if isinstance(x, (bytes, bytearray)):
+            return bytes(x)
+        if hasattr(x, "getvalue"):
+            return x.getvalue()
+        if isinstance(x, memoryview):
+            return x.tobytes()
+        if isinstance(x, str):
+            return x.encode("utf-8")
+        return b""
+    except Exception:
+        return b""
+
 # --------------------- Downloads ---------------------
 
 st.subheader("Downloads")
@@ -676,11 +693,7 @@ with d2:
         except Exception as e:
             kml_bytes = b""
             st.error(f"KML export error: {e}")
-    # Normalize to raw bytes for Streamlit (avoid dict/obj -> RuntimeError)
-    _kml_data = (
-        kml_bytes.getvalue() if hasattr(kml_bytes, "getvalue")
-        else (bytes(kml_bytes) if isinstance(kml_bytes, (bytes, bytearray)) else b"")
-    )
+    _kml_data = _as_bytes(kml_bytes)
     st.download_button(
         label="Download KML",
         data=_kml_data,
@@ -715,11 +728,7 @@ with d4:
         except Exception as e:
             shp_zip = b""
             st.error(f"Shapefile export error: {e}")
-    # Normalize to raw bytes for Streamlit
-    _shp_data = (
-        shp_zip.getvalue() if hasattr(shp_zip, "getvalue")
-        else (bytes(shp_zip) if isinstance(shp_zip, (bytes, bytearray)) else b"")
-    )
+    _shp_data = _as_bytes(shp_zip)
     st.download_button(
         label="Download Shapefile (.zip)",
         data=_shp_data,


### PR DESCRIPTION
### **User description**
## Summary
- add `_as_bytes` helper to standardize bytes conversion for Streamlit
- use helper for KML and shapefile downloads

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3c8cd48fc83278bb6ed67481b8606


___

### **PR Type**
Enhancement


___

### **Description**
- Add `_as_bytes` helper function for standardized byte conversion

- Replace duplicate byte normalization code in KML downloads

- Replace duplicate byte normalization code in shapefile downloads

- Improve error handling with try-catch in helper function


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Duplicate byte conversion code"] --> B["_as_bytes helper function"]
  B --> C["KML download normalization"]
  B --> D["Shapefile download normalization"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>app.py</strong><dd><code>Centralize byte conversion with helper function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app.py

<ul><li>Add <code>_as_bytes</code> helper function with comprehensive type handling<br> <li> Replace inline byte conversion logic in KML download section<br> <li> Replace inline byte conversion logic in shapefile download section<br> <li> Improve code maintainability by eliminating duplication</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/MappingKML/pull/44/files#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959">+19/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

